### PR TITLE
Om 628 bugfix1

### DIFF
--- a/src/devcards/om/devcards/bugs.cljs
+++ b/src/devcards/om/devcards/bugs.cljs
@@ -364,6 +364,66 @@
     (fn [_ node]
       (om/add-root! om-598-reconciler OM-598-App node))))
 
+;; ==================
+;; OM-628
+
+(defn om-628-read
+  [{:keys [state query] :as env} k _]
+  (println "query" query)
+  (let [st @state]
+    {:value (om/db->tree query (get st k) st)}))
+
+(defui om-628-Child
+  static om/Ident
+  (ident [this {:keys [id]}]
+    [:item/by-id id])
+  static om/IQueryParams
+  (params [this]
+    {:count 3})
+  static om/IQuery
+  (query [this]
+    '[:id :title (:items {:count ?count})])
+  Object
+  (render [this]
+    (let [{:keys [title items] :as props} (om/props this)]
+      (dom/div nil
+        (dom/h2 nil title)
+        (dom/ul nil
+          (map-indexed #(dom/li #js {:key %1} (name %2)) items))
+        (dom/button #js {:onClick #(om/set-query!
+                                     this {:query [:id :title]} (om/path this))}
+          "Set this query to: [:id :title]")
+        (dom/button #js {:onClick #(println "my query" (om/get-query this))}
+          "Get local component query")))))
+
+(def om-628-child (om/factory om-628-Child {:keyfn :id}))
+
+(defui om-628-Parent
+  static om/IQuery
+  (query [this]
+    [{:child1 (om/get-query om-628-Child)}
+     {:child2 (om/get-query om-628-Child)}])
+  Object
+  (render [this]
+    (let [{:keys [child1 child2]} (om/props this)]
+      (dom/div nil
+        (dom/p nil (str "Root query: " (om/get-query this)))
+        (om-628-child child1)
+        (om-628-child child2)))))
+
+(defonce om-628-state
+  {:child1 {:id 1 :title "Child 1" :items ["item 1" "item 2"]}
+   :child2 {:id 2 :title "Child 2" :items ["item 1" "item 2"]}})
+
+(def om-628-reconciler
+  (om/reconciler {:state om-628-state
+                  :parser (om/parser {:read om-628-read})}))
+
+(defcard om-628-card
+  (dom-node
+    (fn [_ node]
+      (om/add-root! om-628-reconciler om-628-Parent node))))
+
 
 (comment
 

--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -1077,6 +1077,8 @@
                                 path'          (conj path prop)
                                 rendered-path' (into [] (remove (set union-keys) path'))
                                 cascade-query? (and (= (count (get dp->cs rendered-path')) 1)
+                                                 (= (-> query' meta :component)
+                                                    (-> rendered-path' dp->cs first type))
                                                  (not (map? query')))
                                 query''        (if cascade-query?
                                                  (get-query (first (get dp->cs rendered-path')))

--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -251,30 +251,33 @@
     (cond-> ret
       (and qm (satisfies? IMeta ret)) (with-meta qm))))
 
-(declare component? get-reconciler props)
+(declare component? get-reconciler props class-path get-indexer path)
 
-(defn- get-local-query-data [component]
+(defn- component->query-data [component]
   (some-> (get-reconciler component)
     :config :state deref ::queries (get component)))
 
 (defn get-unbound-query
   "Return the unbound query for a component."
   [component]
-  (:query (get-local-query-data component) (query component)))
+  (:query (component->query-data component) (query component)))
 
 (defn get-params
   "Return the query params for a component."
   [component]
-  (:params (get-local-query-data component) (params component)))
+  (:params (component->query-data component) (params component)))
 
-(defn- get-component-query [c]
-  (let [qps (get-local-query-data c)
-        q   (:query qps (query c))
-        c'  (-> q meta :component)]
-    (assert (nil? c') (str "Query violation, " c , " reuses " c' " query"))
-    (with-meta
-      (bind-query q (:params qps (params c)))
-      {:component (type c)})))
+(defn- get-component-query
+  ([component]
+   (get-component-query component (component->query-data component)))
+  ([component query-data]
+   (let [q  (:query query-data (query component))
+         c' (-> q meta :component)]
+     (assert (nil? c')
+       (str "Query violation, " component " reuses " c' " query"))
+     (with-meta
+       (bind-query q (:params query-data (params component)))
+       {:component (type component)}))))
 
 (defn ^boolean iquery? [x]
   (if (implements? IQuery x)
@@ -283,17 +286,36 @@
       (let [x (js/Object.create (. x -prototype))]
         (implements? IQuery x)))))
 
+(defn- get-class-or-instance-query
+  "Return a IQuery/IParams local bound query. Works for component classes
+   and component instances. Does not use the indexer."
+  [x]
+  (if (component? x)
+    (get-component-query x)
+    (let [q (query x)
+          c (-> q meta :component)]
+      (assert (nil? c) (str "Query violation, " x , " reuses " c " query"))
+      (with-meta (bind-query q (params x)) {:component x}))))
+
 (defn get-query
   "Return a IQuery/IParams instance bound query. Works for component classes
    and component instances. See also om.next/full-query."
   [x]
   (if (implements? IQuery x)
     (if (component? x)
-      (get-component-query x)
-      (let [q (query x)
-            c (-> q meta :component)]
-        (assert (nil? c) (str "Query violation, " x , " reuses " c " query"))
-        (with-meta (bind-query q (params x)) {:component x})))
+      (if-let [query-data (component->query-data x)]
+        (get-component-query x query-data)
+        (let [cp (class-path x)
+              r (get-reconciler x)
+              data-path (into [] (remove number?) (path x))
+              class-path-query-data (get (:class-path->query @(get-indexer r)) cp)
+              qs (filter #(= data-path (-> % zip/root (focus->path data-path)))
+                   class-path-query-data)
+              qs (if (empty? qs) class-path-query-data qs)]
+          (if-not (empty? qs)
+            (zip/node (first qs))
+            (get-class-or-instance-query x))))
+      (get-class-or-instance-query x))
     ;; in advanced, statics will get elided
     (when (goog/isFunction x)
       (let [y (js/Object.create (. x -prototype))]
@@ -957,6 +979,47 @@
 ;; =============================================================================
 ;; Indexer
 
+(defn- cascade-query
+  "Cascades a query up the classpath. class-path->query is a map of classpaths
+   to their queries. classpath is the classpath where we start cascading (typically
+   the direct parent's classpath of the component changing query). data-path is
+   the data path in the classpath's query to the new query. new-query is the
+   query to be applied to the classpaths. union-keys are any keys into union
+   queries found during index building; they are used to access union queries
+   when cascading the classpath, and to generate the classpaths' rendered-paths,
+   which skip these keys."
+  [class-path->query classpath data-path new-query union-keys]
+  (loop [cp classpath
+         data-path data-path
+         new-query new-query
+         ret {}]
+    (if-not (empty? cp)
+      (let [rendered-data-path (into [] (remove (set union-keys)) data-path)
+            filter-data-path (cond-> rendered-data-path
+                               (not (empty? rendered-data-path)) pop)
+            qs (filter #(= filter-data-path
+                           (-> % zip/root (focus->path filter-data-path)))
+                 (get class-path->query cp))
+            qs' (into #{}
+                  (map (fn [q]
+                         (let [new-query (if (or (map? (zip/node q))
+                                               (some #{(peek data-path)} union-keys))
+                                           (let [union-key (peek data-path)]
+                                             (-> (query-template (zip/root q)
+                                                   rendered-data-path)
+                                                 zip/node
+                                                 (assoc union-key new-query)))
+                                           new-query)]
+                           (-> (zip/root q)
+                             (query-template rendered-data-path)
+                             (replace new-query)
+                             (focus-query filter-data-path)
+                             (query-template filter-data-path)))))
+                  qs)]
+        (recur (pop cp) (pop data-path)
+          (-> qs' first zip/node) (assoc ret cp qs')))
+      ret)))
+
 (defrecord Indexer [indexes extfs]
   IDeref
   (-deref [_] @indexes)
@@ -971,7 +1034,7 @@
                 (cond-> prop
                   (and (ident? prop)
                     (= (second prop) '_)) ((comp :dispatch-key parser/expr->ast))))
-              (build-index* [class query path classpath]
+              (build-index* [class query path classpath union-keys]
                 (invariant (or (not (iquery? class))
                              (and (iquery? class)
                                (not (empty? query))))
@@ -984,11 +1047,17 @@
                       classpath  (cond-> classpath
                                    (and (not (nil? class))
                                         (not recursive?))
-                                   (conj class))]
+                                   (conj class))
+                      dp->cs     (get-in @indexes [:data-path->components])]
                   (when class
-                    (swap! class-path->query update-in [classpath]
-                      (fnil conj #{})
-                      (query-template (focus-query rootq path) path)))
+                    (let [focused-query (query-template
+                                          (focus-query rootq path)
+                                          path)
+                          cp-query      (cond-> focused-query
+                                          (not= (zip/node focused-query) query)
+                                          (zip/replace query))]
+                      (swap! class-path->query update-in [classpath]
+                        (fnil conj #{}) cp-query)))
                   (when-not recursive?
                     (cond
                       (vector? query)
@@ -999,26 +1068,64 @@
                                (map get-dispatch-key props)
                                (repeat #{class}))))
                         (doseq [join joins]
-                          (let [[prop query'] (join-entry join)
-                                prop (get-dispatch-key prop)
-                                recursion? (recursion? query')
-                                query'        (if recursion?
-                                                query
-                                                query')]
+                          (let [[prop query']  (join-entry join)
+                                prop           (get-dispatch-key prop)
+                                recursion?     (recursion? query')
+                                query'         (if recursion?
+                                                 query
+                                                 query')
+                                path'          (conj path prop)
+                                rendered-path' (into [] (remove (set union-keys) path'))
+                                cascade-query? (and (= (count (get dp->cs rendered-path')) 1)
+                                                 (not (map? query')))
+                                query''        (if cascade-query?
+                                                 (get-query (first (get dp->cs rendered-path')))
+                                                 query')]
                             (swap! prop->classes
                               #(merge-with into % {prop #{class}}))
-                            (let [class' (-> query' meta :component)]
+                            (when (and cascade-query? (not= query' query''))
+                              (let [cp->q' (cascade-query @class-path->query classpath
+                                             path' query'' union-keys)]
+                                (swap! class-path->query merge cp->q')))
+                            (let [class' (-> query'' meta :component)]
                               (when-not (and recursion? (nil? class'))
-                                (build-index* class' query'
-                                  (conj path prop) classpath))))))
+                                (build-index* class' query''
+                                  path' classpath union-keys))))))
 
                       ;; Union query case
                       (map? query)
                       (doseq [[prop query'] query]
-                        (let [class' (-> query' meta :component)]
-                          (build-index* class' query'
-                            (conj path prop) classpath)))))))]
-        (build-index* class rootq [] [])
+                        (let [path'          (conj path prop)
+                              class'         (-> query' meta :component)
+                              cs             (filter #(= class' (type %))
+                                               (get dp->cs path))
+                              cascade-query? (and class' (= (count cs) 1))
+                              query''        (if cascade-query?
+                                               (get-query (first cs))
+                                               query')]
+                          (when (and cascade-query? (not= query' query''))
+                            (let [qs        (get @class-path->query classpath)
+                                  q         (first qs)
+                                  qnode     (zip/node
+                                              (cond-> q
+                                                (nil? class) (query-template path)))
+                                  new-query (assoc qnode
+                                              prop query'')
+                                  q'        (cond-> (zip/replace
+                                                      (query-template (zip/root q) path)
+                                                      new-query)
+                                              (nil? class)
+                                              (-> zip/root
+                                                (focus-query (pop path))
+                                                (query-template (pop path))))
+                                  qs'       (into #{q'} (remove #{q}) qs)
+                                  cp->q'    (merge {classpath qs'}
+                                              (cascade-query @class-path->query
+                                                (pop classpath) path
+                                                (zip/node q') union-keys))]
+                              (swap! class-path->query merge cp->q')))
+                          (build-index* class' query'' path' classpath (conj union-keys prop))))))))]
+        (build-index* class rootq [] [] [])
         (swap! indexes merge
           {:prop->classes     @prop->classes
            :class-path->query @class-path->query}))))
@@ -1028,6 +1135,10 @@
       (fn [indexes]
         (let [indexes (update-in ((:index-component extfs) indexes c)
                         [:class->components (type c)]
+                        (fnil conj #{}) c)
+              data-path (into [] (remove number?) (path c))
+              indexes (update-in ((:index-component extfs) indexes c)
+                        [:data-path->components data-path]
                         (fnil conj #{}) c)
               ident     (when (implements? Ident c)
                           (let [ident (ident c (props c))]
@@ -1047,6 +1158,10 @@
       (fn [indexes]
         (let [indexes (update-in ((:drop-component extfs) indexes c)
                         [:class->components (type c)]
+                        disj c)
+              data-path (into [] (remove number?) (path c))
+              indexes (update-in ((:drop-component extfs) indexes c)
+                        [:data-path->components data-path]
                         disj c)
               ident     (when (implements? Ident c)
                         (ident c (props c)))]
@@ -1082,6 +1197,7 @@
    (Indexer.
      (atom
        {:class->components {}
+        :data-path->components {}
         :ref->components   {}})
      extfs)))
 

--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -309,6 +309,146 @@
           cps (-> indexes :class-path->query keys)]
       (is (not (nil? (some #{[RootComponent ComponentB]} cps)))))))
 
+(defui Child
+  static om/IQueryParams
+  (params [this]
+    {:count 3})
+  static om/IQuery
+  (query [this]
+    '[:id :title (:items {:count ?count})]))
+
+(defui ToOneRoot
+  static om/IQuery
+  (query [this]
+    [{:tab1 (om/get-query Child)}
+     {:tab2 (om/get-query Child)}]))
+
+(defui ToManyRoot
+  static om/IQuery
+  (query [this]
+    [{:children (om/get-query Child)}]))
+
+(defui UnionChildA
+  static om/IQuery
+  (query [this]
+    [:foo {:nested/join (om/get-query Child)}]))
+
+(defui UnionChildB
+  static om/IQuery
+  (query [this]
+    [:bar]))
+
+(defui UnionRoot
+  static om/IQuery
+  (query [this]
+    [{:union {:foo (om/get-query UnionChildA)
+              :bar (om/get-query UnionChildB)}}]))
+
+(deftest test-indexer-runtime-tree
+  (testing "1->1 joins of the same class in different data paths"
+    (let [r (om/reconciler
+              {:state (atom nil)
+               :parser (om/parser {:read #(do {})})})
+          idxr (get-in r [:config :indexer])
+          ;; simulate mounting
+          _ (p/add-root! r ToOneRoot nil nil)
+          _ (p/index-component! idxr (ToOneRoot. #js {:omcljs$reconciler r
+                                                      :omcljs$path []}))
+          root (-> @idxr :class->components (get ToOneRoot) first)
+          _ (p/index-component! idxr (Child. #js {:omcljs$reconciler r
+                                                  :omcljs$path [:tab1]
+                                                  :omcljs$parent root}))
+          c (first (get-in @idxr [:data-path->components [:tab1]]))]
+      (is (not (nil? c)))
+      ;; will reindex
+      (om/set-query! c {:query [:foo :bar]})
+      (is (= (om/get-query c)
+            [:foo :bar]))
+      (is (= (om/get-query root)
+            '[{:tab1 [:foo :bar]} {:tab2 [:id :title (:items {:count 3})]}]))))
+  (testing "children in 1->many joins changing queries should not be reflected at the root"
+    (let [r (om/reconciler
+              {:state (atom nil)
+               :parser (om/parser {:read #(do {})})})
+          idxr (get-in r [:config :indexer])
+          _ (p/add-root! r ToManyRoot nil nil)
+          _ (p/index-component! idxr (ToManyRoot. #js {:omcljs$reconciler r
+                                                       :omcljs$path []}))
+          root (-> @idxr :class->components (get ToManyRoot) first)
+          children (take 3 (repeatedly
+                             #(Child. #js {:omcljs$reconciler r
+                                           :omcljs$path [:children]
+                                           :omcljs$parent root})))
+          _ (run! #(p/index-component! idxr %) children)
+          c (first (get-in @idxr [:data-path->components [:children]]))]
+      (is (not (nil? c)))
+      (om/set-query! c {:query [:foo :bar]})
+      (is (= (om/get-query c)
+            [:foo :bar]))
+      (is (= (om/get-query root)
+            '[{:children [:id :title (:items {:count 3})]}]))))
+  (testing "1->1 union queries can be changed from below"
+    (let [r (om/reconciler
+              {:state (atom nil)
+               :parser (om/parser {:read #(do {})})})
+          idxr (get-in r [:config :indexer])
+          _ (p/add-root! r UnionRoot nil nil)
+          _ (p/index-component! idxr (UnionRoot. #js {:omcljs$reconciler r
+                                                      :omcljs$path []}))
+          root (-> @idxr :class->components (get UnionRoot) first)
+          child-b (UnionChildB. #js {:omcljs$reconciler r
+                                     :omcljs$path [:union]
+                                     :omcljs$parent root})
+          _ (p/index-component! idxr child-b)
+          c (first (get-in @idxr [:data-path->components [:union]]))]
+      (is (not (nil? c)))
+      (om/set-query! c {:query [:baz :qux]})
+      (is (= (om/get-query c)
+            [:baz :qux]))
+      (is (= (om/get-query root)
+            [{:union {:foo (om/get-query UnionChildA)
+                      :bar [:baz :qux]}}]))
+      ;; changing nested joins in the union
+      (let [child-a (UnionChildA. #js {:omcljs$reconciler r
+                                       :omcljs$path [:union]
+                                       :omcljs$parent root})
+            child-a-child (Child. #js {:omcljs$reconciler r
+                                       :omcljs$path [:union :nested/join]
+                                       :omcljs$parent child-a})
+            _ (p/drop-component! idxr c)
+            _ (p/index-component! idxr child-a)
+            _ (p/index-component! idxr child-a-child)
+            c' (first (get-in @idxr [:data-path->components [:union]]))
+            c-child' (first (get-in @idxr [:data-path->components [:union :nested/join]]))]
+        (is (= c' child-a))
+        (is (not (nil? c-child')))
+        (om/set-query! c-child' {:query [:other/key]})
+        (is (= (om/get-query root)
+              [{:union {:foo [:foo {:nested/join [:other/key]}]
+                        :bar [:baz :qux]}}])))))
+  (testing "query changes in 1->many unions should not be reflected at the root"
+    (let [r (om/reconciler
+              {:state (atom nil)
+               :parser (om/parser {:read #(do {})})})
+          idxr (get-in r [:config :indexer])
+          _ (p/add-root! r UnionRoot nil nil)
+          _ (p/index-component! idxr (UnionRoot. #js {:omcljs$reconciler r
+                                                      :omcljs$path []}))
+          root (-> @idxr :class->components (get UnionRoot) first)
+          children (take 3 (repeatedly
+                             #(UnionChildB. #js {:omcljs$reconciler r
+                                                 :omcljs$path [:union]
+                                                 :omcljs$parent root})))
+          _ (run! #(p/index-component! idxr %) children)
+          c (first (get-in @idxr [:data-path->components [:union]]))]
+      (is (not (nil? c)))
+      (om/set-query! c {:query [:baz :qux]})
+      (is (= (om/get-query c)
+            [:baz :qux]))
+      (is (= (om/get-query root)
+            [{:union {:foo (om/get-query UnionChildA)
+                      :bar (om/get-query UnionChildB)}}])))))
+
 ;; -----------------------------------------------------------------------------
 ;; Parser
 


### PR DESCRIPTION
URL routing scenario bug caused by the sequence

  1. set-query on the app-root
  2. Receive and render data from remote
  3. set-query again on the app-root that causes a different child component to render
  4. BUG The root query resulting from 3 is never sent up to the remote

In devcards:

  Click the Button 'Change Route'. You should expect to see a book title
  "EXPECTED CORRECT BEHAVIOR" but instead a title is never fetched from
  remote so we fall back to the default book title "UNEXPECTED BEHAVIOR"
  which indicates the presence of a bug.